### PR TITLE
configuration.md: clarify public option

### DIFF
--- a/wiki/install/configuration.md
+++ b/wiki/install/configuration.md
@@ -23,7 +23,7 @@ Wiki.js offers various authentication providers that you can enable. See the [au
 
 | Property            | Required | Description                                                                                                                          |   Default Value  |
 |---------------------|:--------:|--------------------------------------------------------------------------------------------------------------------------------------|:----------------:|
-| **public**          | yes      | Should the wiki be accessible publicly without a login. Set to false to require all users to login before accessing any wiki content. | false |
+| **public**          | yes      | Should the wiki be accessible publicly without a login. If set to true, creates a Guest user whose access can be configured in the Users Settings. Set to false to require all users to login before accessing any wiki content. | false |
 | **defaultReadAccess**          | yes      | Should users that logged in using a social authentication provider have read-only access by default. | false |
 | **auth.local.enabled**          | no | Enable the local authentication provider. | true |
 | **auth.google.enabled**         | no | Enable the Google authentication provider | false |


### PR DESCRIPTION
The previous text for the `public` option implied that setting the
value to `true` would create an instance of Wiki.js that would be
accessible without needing to create an account. However, it only
provides the _ability_ to enable public accessibility by creating a
Guest user whose access needs to be configured within the wiki's Users
Settings. By default, the Guest user is denied read access. The help
text for the `public` option has been clarified to reflect this.