### PR TITLE
Clarification to quote the slack client ID

### DIFF
--- a/wiki/install/authentication.md
+++ b/wiki/install/authentication.md
@@ -110,6 +110,9 @@ The Slack provider lets users login using their own Slack account.
 10. Take note of the **Client ID** and **Client Secret** shown under **App Credentials**.
 11. (optional) Upload a logo and customize the look and description of your app.
 
+> :warning: Quote your slack client ID otherwise it will be treated as float instead as a string and this will cut it off.
+{.is-warning}
+
 Under the auth section of your config.yml, you can now enter the required info:
 
 ```yaml


### PR DESCRIPTION
This prevents that the ID gets treated as a float instead of a string.
Otherwise it gets cut of and slack reports an invalid client ID.